### PR TITLE
Readme fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Follow these steps to do a test upgrade of an app, along with a dependency (:tim
 
 - Clone it
 - Prepare deployment directory e.g. `mkdir -p /tmp/test/releases/0.2.0`
-- Fetch deps and build: `cd distillery-test && mix do deps.get, mix compile`
+- Fetch deps and build: `cd distillery-test && mix do deps.get, compile`
 - Build release: `mix release --env=prod`
 - Deploy release: `cp _build/dev/rel/test/releases/0.1.0/test.tar.gz /tmp/test/`
 - Start release: `cd /tmp/test && tar -xf test.tar.gz && ./bin/test start`

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Follow these steps to do a test upgrade of an app, along with a dependency (:tim
 - Verify with:
   - `./bin/test ping`
   - `./bin/test remote_console`
-  - At prompt `:gen_server.call(:test, :ping)`, should return `:v1`
+  - At prompt `GenServer.call(Test.Server, :ping)`, should return `:v1`
 - Make some changes, bump the version to `0.2.0`
 - `mix release --env=prod --upgrade`
 - Deploy upgrade: `cp _build/dev/rel/test/releases/0.2.0/test.tar.gz /tmp/test/releases/0.2.0/`


### PR DESCRIPTION
I just adjusted two things in the readme, which gave me some trouble while trying out the test project here.

- Removed extra `mix` from `mix do`. Got a `** (Mix) The task "mix" could not be found` error message.
- Name of the test GenServer is `Test.Server`, not `:test`.